### PR TITLE
Add initial Flutter wireframe for device pairing and alarm

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+
+import 'models/device.dart';
+
+class AppState extends ChangeNotifier {
+  String? role; // 'parent' or 'child'
+  String? pairingCode;
+  DateTime? codeExpiry;
+  Timer? _codeTimer;
+  final List<Device> devices = [];
+
+  void setRole(String? newRole) {
+    role = newRole;
+    notifyListeners();
+  }
+
+  void generateCode() {
+    final rnd = Random();
+    pairingCode = List.generate(6, (_) => rnd.nextInt(10)).join();
+    codeExpiry = DateTime.now().add(const Duration(minutes: 5));
+    _codeTimer?.cancel();
+    _codeTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (DateTime.now().isAfter(codeExpiry!)) {
+        pairingCode = null;
+        timer.cancel();
+        notifyListeners();
+      } else {
+        notifyListeners();
+      }
+    });
+    notifyListeners();
+  }
+
+  Duration? get remaining =>
+      codeExpiry != null ? codeExpiry!.difference(DateTime.now()) : null;
+
+  bool verifyCode(String code) {
+    return pairingCode == code && remaining! > Duration.zero;
+  }
+
+  void addDevice(Device device) {
+    devices.add(device);
+    notifyListeners();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'app_state.dart';
+import 'screens/role_selection.dart';
+import 'screens/parent_code_screen.dart';
+import 'screens/child_pairing_screen.dart';
+import 'screens/parent_home_screen.dart';
+import 'screens/child_alarm_screen.dart';
+import 'screens/settings_help_screen.dart';
+
+void main() {
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => AppState(),
+      child: const KokodayoApp(),
+    ),
+  );
+}
+
+class KokodayoApp extends StatelessWidget {
+  const KokodayoApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Kokodayo',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      initialRoute: '/',
+      routes: {
+        '/': (context) => const RoleSelectionScreen(),
+        '/parentCode': (context) => const ParentCodeScreen(),
+        '/childPair': (context) => const ChildPairingScreen(),
+        '/parentHome': (context) => const ParentHomeScreen(),
+        '/childAlarm': (context) => const ChildAlarmScreen(),
+        '/settings': (context) => const SettingsHelpScreen(),
+      },
+    );
+  }
+}

--- a/lib/models/device.dart
+++ b/lib/models/device.dart
@@ -1,0 +1,7 @@
+class Device {
+  Device({required this.name, this.online = true, required this.lastSeen});
+
+  final String name;
+  bool online;
+  DateTime lastSeen;
+}

--- a/lib/screens/child_alarm_screen.dart
+++ b/lib/screens/child_alarm_screen.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+class ChildAlarmScreen extends StatefulWidget {
+  const ChildAlarmScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ChildAlarmScreen> createState() => _ChildAlarmScreenState();
+}
+
+class _ChildAlarmScreenState extends State<ChildAlarmScreen> {
+  late Timer _timer;
+  int _seconds = 60;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (_seconds <= 1) {
+        timer.cancel();
+        Navigator.pop(context);
+      } else {
+        setState(() => _seconds--);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.volume_up, size: 64),
+            const SizedBox(height: 16),
+            const Text('端末を探しています…'),
+            const SizedBox(height: 32),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('停止'),
+            ),
+            const SizedBox(height: 16),
+            Text('自動停止まで $_seconds 秒'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/child_pairing_screen.dart
+++ b/lib/screens/child_pairing_screen.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../app_state.dart';
+import '../models/device.dart';
+
+class ChildPairingScreen extends StatefulWidget {
+  const ChildPairingScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ChildPairingScreen> createState() => _ChildPairingScreenState();
+}
+
+class _ChildPairingScreenState extends State<ChildPairingScreen> {
+  final _codeController = TextEditingController();
+  final _nameController = TextEditingController();
+  bool _verified = false;
+  String? _error;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.watch<AppState>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('ペアリング')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: !_verified ? _buildCodeInput(state) : _buildNickname(state),
+      ),
+    );
+  }
+
+  Widget _buildCodeInput(AppState state) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('親の画面に表示された6桁コードを入力してください'),
+        TextField(
+          controller: _codeController,
+          maxLength: 6,
+          keyboardType: TextInputType.number,
+          decoration: InputDecoration(errorText: _error),
+        ),
+        const Spacer(),
+        Center(
+          child: ElevatedButton(
+            onPressed: () {
+              if (state.verifyCode(_codeController.text)) {
+                setState(() {
+                  _verified = true;
+                  _error = null;
+                });
+              } else {
+                setState(() {
+                  _error = 'コードが無効です';
+                });
+              }
+            },
+            child: const Text('次へ'),
+          ),
+        )
+      ],
+    );
+  }
+
+  Widget _buildNickname(AppState state) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('この端末の名前'),
+        TextField(
+          controller: _nameController,
+          decoration: const InputDecoration(hintText: '娘のスマホ'),
+        ),
+        const Spacer(),
+        Center(
+          child: ElevatedButton(
+            onPressed: () {
+              state.addDevice(Device(
+                  name: _nameController.text.isEmpty
+                      ? '未設定'
+                      : _nameController.text,
+                  lastSeen: DateTime.now()));
+              Navigator.pushReplacementNamed(context, '/childAlarm');
+            },
+            child: const Text('完了'),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/screens/parent_code_screen.dart
+++ b/lib/screens/parent_code_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../app_state.dart';
+
+class ParentCodeScreen extends StatefulWidget {
+  const ParentCodeScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ParentCodeScreen> createState() => _ParentCodeScreenState();
+}
+
+class _ParentCodeScreenState extends State<ParentCodeScreen> {
+  @override
+  void initState() {
+    super.initState();
+    final state = context.read<AppState>();
+    state.generateCode();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.watch<AppState>();
+    final remaining = state.remaining;
+    final minutes = remaining != null ? remaining.inMinutes.remainder(60) : 0;
+    final seconds = remaining != null ? remaining.inSeconds.remainder(60) : 0;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('デバイスを追加'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('子端末に表示/入力してもらう「家族コード」'),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(24),
+              decoration: BoxDecoration(
+                  border: Border.all(color: Colors.black45, width: 2)),
+              child: Text(
+                state.pairingCode ?? '------',
+                style: const TextStyle(fontSize: 32, letterSpacing: 4),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text('残り ${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')} で更新'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => state.generateCode(),
+              child: const Text('コードを更新'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pushReplacementNamed(context, '/parentHome');
+              },
+              child: const Text('ホームへ'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/parent_home_screen.dart
+++ b/lib/screens/parent_home_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../app_state.dart';
+import '../models/device.dart';
+
+class ParentHomeScreen extends StatelessWidget {
+  const ParentHomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.watch<AppState>();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('迷子スマホ探索'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () {
+              Navigator.pushNamed(context, '/parentCode');
+            },
+          )
+        ],
+      ),
+      drawer: Drawer(
+        child: ListView(
+          children: [
+            const DrawerHeader(child: Text('メニュー')),
+            ListTile(
+              title: const Text('設定 & ヘルプ'),
+              onTap: () => Navigator.pushNamed(context, '/settings'),
+            ),
+          ],
+        ),
+      ),
+      body: state.devices.isEmpty
+          ? const Center(child: Text('まだデバイスがありません'))
+          : ListView.builder(
+              itemCount: state.devices.length,
+              itemBuilder: (context, index) {
+                final device = state.devices[index];
+                return _DeviceTile(device: device);
+              },
+            ),
+    );
+  }
+}
+
+class _DeviceTile extends StatelessWidget {
+  const _DeviceTile({required this.device});
+  final Device device;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(device.online ? Icons.circle : Icons.circle_outlined,
+          color: device.online ? Colors.green : Colors.grey),
+      title: Text(device.name),
+      subtitle: Text('最終: ${device.lastSeen.hour.toString().padLeft(2, '0')}:${device.lastSeen.minute.toString().padLeft(2, '0')}'),
+      trailing: ElevatedButton(
+        onPressed: device.online
+            ? () {
+                ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('${device.name} を鳴らします')));
+              }
+            : null,
+        child: const Text('鳴らす'),
+      ),
+    );
+  }
+}

--- a/lib/screens/role_selection.dart
+++ b/lib/screens/role_selection.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../app_state.dart';
+
+class RoleSelectionScreen extends StatefulWidget {
+  const RoleSelectionScreen({Key? key}) : super(key: key);
+
+  @override
+  State<RoleSelectionScreen> createState() => _RoleSelectionScreenState();
+}
+
+class _RoleSelectionScreenState extends State<RoleSelectionScreen> {
+  String? _role;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.watch<AppState>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('迷子スマホ探索')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('この端末の役割を選んでください'),
+            RadioListTile<String>(
+              title: const Text('親（探す側）'),
+              value: 'parent',
+              groupValue: _role,
+              onChanged: (v) => setState(() => _role = v),
+            ),
+            RadioListTile<String>(
+              title: const Text('子（鳴らされる側）'),
+              value: 'child',
+              groupValue: _role,
+              onChanged: (v) => setState(() => _role = v),
+            ),
+            const Spacer(),
+            Center(
+              child: ElevatedButton(
+                onPressed: _role == null
+                    ? null
+                    : () {
+                        state.setRole(_role);
+                        if (_role == 'parent') {
+                          Navigator.pushReplacementNamed(
+                              context, '/parentCode');
+                        } else {
+                          Navigator.pushReplacementNamed(
+                              context, '/childPair');
+                        }
+                      },
+                child: const Text('はじめる'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_help_screen.dart
+++ b/lib/screens/settings_help_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../app_state.dart';
+
+class SettingsHelpScreen extends StatelessWidget {
+  const SettingsHelpScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.watch<AppState>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('設定 & ヘルプ')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          ListTile(
+            title: const Text('役割'),
+            subtitle: Text(state.role == 'parent' ? '親' : '子'),
+          ),
+          ListTile(
+            title: const Text('通知の状態'),
+            subtitle: const Text('許可済'),
+          ),
+          const Divider(),
+          const ListTile(
+            title: Text('ヘルプ'),
+            subtitle: Text('・オフラインだと鳴らせません\n・iOSはサイレント/集中モード中は鳴りません\n・安全のため音量にご注意ください'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: kokodayo
+version: 0.1.0
+publish_to: 'none'
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- initialize Flutter app with Provider state management
- add role selection, code pairing, parent home, child alarm, and settings screens
- support basic code generation and pairing logic

## Testing
- `dart --version` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68af17eed8c88332b1d5e2b0ad99657a