### PR TITLE
feat: remove provider package and add simple provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ migrate_working_dir/
 .pub/
 /build/
 /coverage/
+.codex_cache/
 
 # Symbolication related
 app.*.symbols

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:kokodayo/simple_provider.dart';
 
 import 'app_state.dart';
 import 'screens/role_selection.dart';

--- a/lib/screens/child_pairing_screen.dart
+++ b/lib/screens/child_pairing_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:kokodayo/simple_provider.dart';
 
 import '../app_state.dart';
 import '../models/device.dart';

--- a/lib/screens/parent_code_screen.dart
+++ b/lib/screens/parent_code_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:kokodayo/simple_provider.dart';
 
 import '../app_state.dart';
 

--- a/lib/screens/parent_home_screen.dart
+++ b/lib/screens/parent_home_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:kokodayo/simple_provider.dart';
 
 import '../app_state.dart';
 import '../models/device.dart';

--- a/lib/screens/role_selection.dart
+++ b/lib/screens/role_selection.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:kokodayo/simple_provider.dart';
 
 import '../app_state.dart';
 

--- a/lib/screens/settings_help_screen.dart
+++ b/lib/screens/settings_help_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:kokodayo/simple_provider.dart';
 
 import '../app_state.dart';
 

--- a/lib/simple_provider.dart
+++ b/lib/simple_provider.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// A very small subset of the functionality offered by the `provider` package.
+/// It is sufficient for the sample app which only needs a [ChangeNotifier]
+/// based provider with `watch`/`read` helpers on [BuildContext].
+class ChangeNotifierProvider<T extends ChangeNotifier> extends StatefulWidget {
+  const ChangeNotifierProvider({
+    Key? key,
+    required this.create,
+    required this.child,
+  }) : super(key: key);
+
+  final T Function(BuildContext) create;
+  final Widget child;
+
+  @override
+  State<ChangeNotifierProvider<T>> createState() => _ChangeNotifierProviderState<T>();
+
+  static T _watch<T extends ChangeNotifier>(BuildContext context) {
+    final provider =
+        context.dependOnInheritedWidgetOfExactType<_InheritedProvider<T>>();
+    assert(provider != null, 'No ChangeNotifierProvider<$T> found in context');
+    return provider!.notifier!;
+  }
+
+  static T _read<T extends ChangeNotifier>(BuildContext context) {
+    final element =
+        context.getElementForInheritedWidgetOfExactType<_InheritedProvider<T>>();
+    final provider = element?.widget as _InheritedProvider<T>?;
+    assert(provider != null, 'No ChangeNotifierProvider<$T> found in context');
+    return provider!.notifier!;
+  }
+}
+
+class _ChangeNotifierProviderState<T extends ChangeNotifier>
+    extends State<ChangeNotifierProvider<T>> {
+  late T _notifier;
+
+  @override
+  void initState() {
+    super.initState();
+    _notifier = widget.create(context);
+  }
+
+  @override
+  void dispose() {
+    _notifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _InheritedProvider<T>(notifier: _notifier, child: widget.child);
+  }
+}
+
+class _InheritedProvider<T extends ChangeNotifier> extends InheritedNotifier<T> {
+  const _InheritedProvider({
+    Key? key,
+    required T notifier,
+    required Widget child,
+  }) : super(key: key, notifier: notifier, child: child);
+}
+
+extension SimpleProviderContext on BuildContext {
+  /// Obtain the nearest provided [ChangeNotifier] and subscribe to changes.
+  T watch<T extends ChangeNotifier>() =>
+      ChangeNotifierProvider._watch<T>(this);
+
+  /// Obtain the nearest provided [ChangeNotifier] without subscribing.
+  T read<T extends ChangeNotifier>() =>
+      ChangeNotifierProvider._read<T>(this);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,5 +209,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,12 +3,11 @@ version: 0.1.0
 publish_to: 'none'
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  provider: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- replace `provider` dependency with a tiny in-house implementation
- update imports to use the new provider
- clean up pubspec and ignore temporary cache files

## Testing
- ⚠️ `dart --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c412c77483328cf4cd2cdff910b7